### PR TITLE
Limit displayed contents by category

### DIFF
--- a/src/components/Card/CardList.test.tsx
+++ b/src/components/Card/CardList.test.tsx
@@ -10,11 +10,22 @@ describe("CardList component", () => {
   //   { index: 2, title: "Card 3", description: "This is card 3", src: "src3" },
   // ];
 
-  it("renders a list of cards", () => {
-    const { getByRole } = render(<CardList />);
+  it("renders a list of all cards if no category is supplied", () => {
+    const { getByRole } = render(<CardList category=""/>);
     const cardItems = getByRole("list");
     // TODO: this is flaky because it depends on how nested we put the CardItem components
     expect(cardItems.childNodes.length).toBe(3);
+  });
+
+  it("renders a list of cards with the matching category", () => {
+    const { getByRole } = render(<CardList category="category2"/>);
+    const cardItems = getByRole("list");
+    expect(cardItems.childNodes.length).toBe(2);
+  });
+
+  it("renders an error page when there is no matching category", () => {
+    expect(() => render(<CardList category="not-a-matching-category"/>))
+      .toThrow("Sorry, we do not have any content in that category. But please check back later. We are constantly adding new content!");
   });
 
   // it("calls the onSwipe function when a card is swiped", () => {

--- a/src/components/Card/CardList.test.tsx
+++ b/src/components/Card/CardList.test.tsx
@@ -1,9 +1,15 @@
 import { render } from "@testing-library/react";
 import React from "react";
+import * as ReactRouterDOM from "react-router-dom";
 
 import { CardList } from "./CardList";
 
-describe("CardList component", () => {
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: jest.fn(),
+ }));
+
+ describe("CardList component", () => {
   // const mockCards = [
   //   { index: 0, title: "Card 1", description: "This is card 1", src: "src1" },
   //   { index: 1, title: "Card 2", description: "This is card 2", src: "src2" },
@@ -11,20 +17,29 @@ describe("CardList component", () => {
   // ];
 
   it("renders a list of all cards if no category is supplied", () => {
-    const { getByRole } = render(<CardList category=""/>);
+    const params = {}
+    jest.spyOn(ReactRouterDOM, "useParams").mockReturnValue(params);
+
+    const { getByRole } = render(<CardList />);
     const cardItems = getByRole("list");
     // TODO: this is flaky because it depends on how nested we put the CardItem components
     expect(cardItems.childNodes.length).toBe(3);
   });
 
   it("renders a list of cards with the matching category", () => {
-    const { getByRole } = render(<CardList category="category2"/>);
+    const params = { category: "category2" };
+    jest.spyOn(ReactRouterDOM, "useParams").mockReturnValue(params);
+
+    const { getByRole } = render(<CardList />);
     const cardItems = getByRole("list");
     expect(cardItems.childNodes.length).toBe(2);
   });
 
   it("renders an error page when there is no matching category", () => {
-    expect(() => render(<CardList category="not-a-matching-category"/>))
+    const params = { category: "not-a-matching-category" };
+    jest.spyOn(ReactRouterDOM, "useParams").mockReturnValue(params);
+
+    expect(() => render(<CardList />))
       .toThrow("Sorry, we do not have any content in that category. But please check back later. We are constantly adding new content!");
   });
 

--- a/src/components/Card/CardList.tsx
+++ b/src/components/Card/CardList.tsx
@@ -2,22 +2,20 @@ import "./Card.scss";
 
 import React, { useState } from "react";
 import { Container } from "react-bootstrap";
+import { useParams } from "react-router-dom";
 
 import { mockCards } from "../../services/mockCardData";
 import { logger } from "../../utils/logger";
 import { CardItem } from "./CardItem";
 
-export interface CardListProps {
-  category: string;
-}
-
-export function CardList({ category }: CardListProps) {
+export function CardList() {
   const [lastDirection, setLastDirection] = useState("");
+  const { category } = useParams();
 
   // If no category is supplied, use all cards.
   // Otherwise, use cards with a matching category
   const cards =
-    category === ""
+    category === undefined
       ? mockCards
       : mockCards.filter((mockCard) => mockCard.categories.includes(category));
 

--- a/src/components/Card/CardList.tsx
+++ b/src/components/Card/CardList.tsx
@@ -7,9 +7,25 @@ import { mockCards } from "../../services/mockCardData";
 import { logger } from "../../utils/logger";
 import { CardItem } from "./CardItem";
 
-export function CardList() {
+export interface CardListProps {
+  category: string;
+}
+
+export function CardList({ category }: CardListProps) {
   const [lastDirection, setLastDirection] = useState("");
-  const cards = mockCards;
+
+  // If no category is supplied, use all cards.
+  // Otherwise, use cards with a matching category
+  const cards =
+    category === ""
+      ? mockCards
+      : mockCards.filter((mockCard) => mockCard.categories.includes(category));
+
+  // Throw error if there are no matching cards
+  if (cards.length === 0)
+    throw new Error(
+      "Sorry, we do not have any content in that category. But please check back later. We are constantly adding new content!"
+    );
 
   const swiped = (direction: string, nameToDelete: string) => {
     logger.info(`removing: ${nameToDelete}`);
@@ -19,8 +35,6 @@ export function CardList() {
   const outOfFrame = (title: string) => {
     logger.info(`${title} left the screen!`);
   };
-
-  // useEffect(() => {
 
   return (
     <Container

--- a/src/pages/App/App.test.tsx
+++ b/src/pages/App/App.test.tsx
@@ -33,7 +33,7 @@ test("routes correctly and renders key pages", async () => {
 });
 
 test("renders error page when route is not found", () => {
-  const badRoute = "/not-a-route";
+  const badRoute = "/help/not-a-route";
   const router = createMemoryRouter(routesConfig, {
     initialEntries: [badRoute],
   });

--- a/src/pages/Error/Error.test.tsx
+++ b/src/pages/Error/Error.test.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { MemoryRouter, isRouteErrorResponse } from "react-router-dom";
+import * as ReactRouterDOM from "react-router-dom";
+
+import { Error } from "./Error";
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useRouteError: jest.fn(),
+ }));
+
+ describe("Error component", () => {
+  it("renders default error message when no message prop is passed", () => {
+    const { getByText } = render(
+      <MemoryRouter>
+        <Error />
+      </MemoryRouter>
+    );
+
+    expect(getByText("Sorry, an unexpected error has occurred.")).toBeInTheDocument();
+  });
+
+  it("renders custom error message when message prop is passed", () => {
+    const error = { message: "Custom error message" };
+    jest.spyOn(ReactRouterDOM, "useRouteError").mockReturnValue(error);
+
+    const { getByText } = render(
+      <MemoryRouter>
+        <Error />
+      </MemoryRouter>
+    );
+
+    expect(getByText("Custom error message")).toBeInTheDocument();
+  });
+
+  it("displays route error response when there's an error object returned by useRouteError", () => {
+    const error = { status: 404, statusText: "Not Found" };
+    jest.spyOn(ReactRouterDOM, "useRouteError").mockReturnValue(error);
+
+    const { getByText } = render(
+      <MemoryRouter>
+        <Error />
+      </MemoryRouter>
+    );
+
+    expect(getByText(`${error.status} ${error.statusText}`)).toBeInTheDocument();
+  });
+
+  it("doesn't display route error response when there's no error object returned by useRouteError", () => {
+    jest.spyOn(ReactRouterDOM, "useRouteError").mockReturnValue(null);
+
+    const { queryByText } = render(
+      <MemoryRouter>
+        <Error />
+      </MemoryRouter>
+    );
+
+    expect(queryByText(/(\d+) (\w+)/)).toBeNull();
+  });
+});

--- a/src/pages/Error/Error.test.tsx
+++ b/src/pages/Error/Error.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import { MemoryRouter, isRouteErrorResponse } from "react-router-dom";
+import { MemoryRouter } from "react-router-dom";
 import * as ReactRouterDOM from "react-router-dom";
 
 import { Error } from "./Error";

--- a/src/pages/Error/Error.tsx
+++ b/src/pages/Error/Error.tsx
@@ -1,22 +1,26 @@
 import React from "react";
-import { isRouteErrorResponse, useRouteError } from "react-router-dom";
+import { useRouteError } from "react-router-dom";
 
-function Error() {
-  const error = useRouteError();
+import { MainHeader } from "../../components/MainHeader";
+
+export function Error() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const error: any = useRouteError();
 
   return (
     <div id="error-page">
+      <MainHeader />
       <h1>Oops!</h1>
-      <p>Sorry, an unexpected error has occurred.</p>
+      {(error && error.message && <p>{error.message}</p>) || (
+        <p>Sorry, an unexpected error has occurred.</p>
+      )}
       <div>
-        {(isRouteErrorResponse(error) && (
+        {error && error.status && error.statusText && (
           <p>
             {error.status} {error.statusText}
           </p>
-        )) || <p>Error message unknown!</p>}
+        )}
       </div>
     </div>
   );
 }
-
-export default Error;

--- a/src/pages/Error/index.tsx
+++ b/src/pages/Error/index.tsx
@@ -1,1 +1,1 @@
-export { default as Error } from "./Error";
+export * from "./Error";

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -2,19 +2,16 @@ import "./Main.scss";
 
 import React from "react";
 import { Container } from "react-bootstrap";
-import { useParams } from "react-router-dom";
 
 import { CardList } from "../../components/Card";
 import { MainHeader } from "../../components/MainHeader";
 
 function Main() {
-  const { category } = useParams();
-
   return (
     <div className="main" role="main">
       <MainHeader />
       <Container>
-        <CardList category={category || ""} />
+        <CardList />
       </Container>
     </div>
   );

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -2,16 +2,19 @@ import "./Main.scss";
 
 import React from "react";
 import { Container } from "react-bootstrap";
+import { useParams } from "react-router-dom";
 
 import { CardList } from "../../components/Card";
 import { MainHeader } from "../../components/MainHeader";
 
 function Main() {
+  const { category } = useParams();
+
   return (
     <div className="main" role="main">
       <MainHeader />
       <Container>
-        <CardList />
+        <CardList category={category || ""} />
       </Container>
     </div>
   );

--- a/src/pages/routes.tsx
+++ b/src/pages/routes.tsx
@@ -12,6 +12,11 @@ export const routesConfig = [
     errorElement: <Error />,
   },
   {
+    path: "/:category",
+    element: <Main />,
+    errorElement: <Error />,
+  },
+  {
     path: "/help",
     element: <Help />,
     errorElement: <Error />,


### PR DESCRIPTION
This PR:
- adds a `/:category` URL param to the routes
- shows cards that match the category
- shows all cards if no category is supplied
- shows an error if the supplied category does not match any cards