### PR TITLE
Store seen cards' links in localstorage

### DIFF
--- a/src/components/Card/CardList.test.tsx
+++ b/src/components/Card/CardList.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import React from "react";
 import * as ReactRouterDOM from "react-router-dom";
 
@@ -64,6 +64,10 @@ describe("CardList component", () => {
     expect(() => render(<CardList {...mockCardListProps} />)).toThrow(
       "Sorry, we do not have any content in that category. But please check back later. We are constantly adding new content!"
     );
+  });
+
+  it("adds a card link to localstorage when card item is swiped", () => {
+    // TODO
   });
 
   // it("calls the onSwipe function when a card is swiped", () => {

--- a/src/components/Card/CardList.tsx
+++ b/src/components/Card/CardList.tsx
@@ -56,7 +56,7 @@ export function CardList({
 
   return (
     <Container fluid>
-      <Row className="d-grid justify-content-center">
+      <Row className="d-grid justify-content-center" role="list">
         {cards.map((card) => (
           <CardItem
             key={card.link}

--- a/src/components/Quiz/QuizModal.tsx
+++ b/src/components/Quiz/QuizModal.tsx
@@ -1,6 +1,7 @@
 import "./QuizModal.scss";
 
 import React, { useEffect, useState } from "react";
+import { Button, Form } from "react-bootstrap";
 import Modal from "react-bootstrap/Modal";
 
 import { CardItemData } from "../Card";
@@ -8,7 +9,7 @@ import { CardItemData } from "../Card";
 export interface QuizModalProps {
   card: CardItemData | null;
   show: boolean;
-  handleClose: () => void;
+  handleClose: (isCompleted: boolean) => void;
 }
 
 export const motivationalMessages = [
@@ -22,6 +23,48 @@ export const motivationalMessages = [
   "Woohoo!",
 ];
 
+export interface QuizFormProps {
+  handleClose: (isCompleted: boolean) => void;
+}
+
+// TODO: replace with proper quiz logic
+function QuizForm(props: QuizFormProps) {
+  const [formValue, setFormValue] = useState(false);
+  const { handleClose } = props;
+
+  return (
+    <Form
+      onSubmit={(ev) => {
+        ev.preventDefault();
+        handleClose(formValue);
+      }}
+    >
+      <div key="default-radio" className="mb-3">
+        <Form.Check
+          type="radio"
+          id="quiz-radio-true"
+          label="true (correct answer)"
+          value="true"
+          checked={formValue === true}
+          onChange={() => setFormValue(true)}
+        />
+
+        <Form.Check
+          type="radio"
+          label="false"
+          id="quiz-radio-false"
+          value="false"
+          checked={formValue === false}
+          onChange={() => setFormValue(false)}
+        />
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
+      </div>
+    </Form>
+  );
+}
+
 export function QuizModal({ card, show, handleClose }: QuizModalProps) {
   const [message, setMessage] = useState(motivationalMessages[0]);
 
@@ -34,7 +77,12 @@ export function QuizModal({ card, show, handleClose }: QuizModalProps) {
   }, [card]);
 
   return (
-    <Modal onHide={handleClose} show={show} backdrop="static" keyboard={false}>
+    <Modal
+      onHide={() => handleClose(false)}
+      show={show}
+      backdrop="static"
+      keyboard={false}
+    >
       <Modal.Header closeButton>
         <Modal.Title>{message}</Modal.Title>
       </Modal.Header>
@@ -48,6 +96,11 @@ export function QuizModal({ card, show, handleClose }: QuizModalProps) {
           </a>
         </h3>
         <p>Hello! This is your quiz</p>
+        <QuizForm
+          handleClose={(isCompleted) => {
+            handleClose(isCompleted);
+          }}
+        />
       </Modal.Body>
     </Modal>
   );

--- a/src/pages/Main/Main.test.tsx
+++ b/src/pages/Main/Main.test.tsx
@@ -3,8 +3,14 @@ import React from "react";
 import { renderWithRouter } from "../../utils/testHelpers";
 import Main from "./Main";
 
-test("checks that main is rendered", () => {
-  const { getByRole } = renderWithRouter(<Main />);
-  const headerImage = getByRole("main");
-  expect(headerImage).toBeInTheDocument();
+describe("Main component", () => {
+  test("checks that main is rendered", () => {
+    const { getByRole } = renderWithRouter(<Main />);
+    const headerImage = getByRole("main");
+    expect(headerImage).toBeInTheDocument();
+  });
+
+  test("it stores links for completed quizzes in localstorage", () => {
+    // TODO
+  });
 });

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -24,18 +24,29 @@ function Main() {
     logger.info(`Removing ${card.title}`);
   };
 
-  useEffect(() => {
-    const completedCardLinks: string[] = JSON.parse(
-      localStorage.getItem("eras.completedCardLinks") || "[]"
-    );
+  const getCardLinks = (): string[] => {
+    return JSON.parse(localStorage.getItem("eras.completedCardLinks") || "[]");
+  };
 
-    // Pushes empty string into the array when initialized
-    // Leaving the empty string seem less harmful than checking that every `lastCompletedCardLink !== ""`
+  const storeCardLinks = (cardLinks: string[]) => {
+    localStorage.setItem("eras.completedCardLinks", JSON.stringify(cardLinks));
+  };
+
+  useEffect(() => {
+    const completedCardLinks = getCardLinks();
+
     completedCardLinks.push(lastCompletedCardLink);
-    localStorage.setItem(
-      "eras.completedCardLinks",
-      JSON.stringify(completedCardLinks)
-    );
+    storeCardLinks(completedCardLinks);
+
+    return () => {
+      const cardLinksToCleanUp = getCardLinks();
+
+      const cleanedUpCardLinks = cardLinksToCleanUp.filter((link) => {
+        return link !== "";
+      });
+
+      storeCardLinks(cleanedUpCardLinks);
+    };
   }, [lastCompletedCardLink]);
 
   return (

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -48,9 +48,9 @@ function Main() {
         <QuizModal
           card={quizState.activeQuiz}
           show={quizState.showModal}
-          handleClose={() => {
+          handleClose={(isCompleted: boolean) => {
             const link = quizState.activeQuiz?.link;
-            if (link) setLastCardLink(link);
+            if (isCompleted && link) setLastCardLink(link);
             setQuizState({ activeQuiz: null, showModal: false });
           }}
         />

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -13,7 +13,7 @@ function Main() {
     activeQuiz: CardItemData | null;
     showModal: boolean;
   }>({ activeQuiz: null, showModal: false });
-  const [lastCardLink, setLastCardLink] = useState("");
+  const [lastCompletedCardLink, setLastCompletedCardLink] = useState("");
 
   const handleSelect = (card: CardItemData) => {
     setQuizState({ activeQuiz: card, showModal: true });
@@ -25,15 +25,18 @@ function Main() {
   };
 
   useEffect(() => {
-    const cardLinks: string[] = JSON.parse(
-      localStorage.getItem("eras.cardLinks") || "[]"
+    const completedCardLinks: string[] = JSON.parse(
+      localStorage.getItem("eras.completedCardLinks") || "[]"
     );
 
     // Pushes empty string into the array when initialized
-    // Leaving the empty string seem less harmful than checking that every `lastCardLink !== ""`
-    cardLinks.push(lastCardLink);
-    localStorage.setItem("eras.cardLinks", JSON.stringify(cardLinks));
-  }, [lastCardLink]);
+    // Leaving the empty string seem less harmful than checking that every `lastCompletedCardLink !== ""`
+    completedCardLinks.push(lastCompletedCardLink);
+    localStorage.setItem(
+      "eras.completedCardLinks",
+      JSON.stringify(completedCardLinks)
+    );
+  }, [lastCompletedCardLink]);
 
   return (
     <div className="main" role="main">
@@ -50,7 +53,7 @@ function Main() {
           show={quizState.showModal}
           handleClose={(isCompleted: boolean) => {
             const link = quizState.activeQuiz?.link;
-            if (isCompleted && link) setLastCardLink(link);
+            if (isCompleted && link) setLastCompletedCardLink(link);
             setQuizState({ activeQuiz: null, showModal: false });
           }}
         />

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -1,6 +1,6 @@
 import "./Main.scss";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { CardItemData, CardList } from "../../components/Card";
 import { MainHeader } from "../../components/MainHeader";
@@ -13,6 +13,7 @@ function Main() {
     activeQuiz: CardItemData | null;
     showModal: boolean;
   }>({ activeQuiz: null, showModal: false });
+  const [lastCardLink, setLastCardLink] = useState("");
 
   const handleSelect = (card: CardItemData) => {
     setQuizState({ activeQuiz: card, showModal: true });
@@ -22,6 +23,17 @@ function Main() {
     // TODO: add this to the user's history
     logger.info(`Removing ${card.title}`);
   };
+
+  useEffect(() => {
+    const cardLinks: string[] = JSON.parse(
+      localStorage.getItem("eras.cardLinks") || "[]"
+    );
+
+    // Pushes empty string into the array when initialized
+    // Leaving the empty string seem less harmful than checking that every `lastCardLink !== ""`
+    cardLinks.push(lastCardLink);
+    localStorage.setItem("eras.cardLinks", JSON.stringify(cardLinks));
+  }, [lastCardLink]);
 
   return (
     <div className="main" role="main">
@@ -36,9 +48,11 @@ function Main() {
         <QuizModal
           card={quizState.activeQuiz}
           show={quizState.showModal}
-          handleClose={() =>
-            setQuizState({ activeQuiz: null, showModal: false })
-          }
+          handleClose={() => {
+            const link = quizState.activeQuiz?.link;
+            if (link) setLastCardLink(link);
+            setQuizState({ activeQuiz: null, showModal: false });
+          }}
         />
       )}
     </div>


### PR DESCRIPTION
This PR stores the seen content items (cards) in the browser's localstorage.

This will eventually be changed to instead or additionally store which content items' games/quizzes have been passed.