### PR TITLE
Fix clickability of links in Tinder Cards

### DIFF
--- a/src/components/Card/CardItem.tsx
+++ b/src/components/Card/CardItem.tsx
@@ -38,9 +38,14 @@ export function CardItem({
           <Card.Title>{title}</Card.Title>
           <Card.Text>{text}</Card.Text>
           <Card.Footer className="mt-auto">
-            <a href={link} target="_blank" rel="noreferrer">
+            <Card.Link
+              href={link}
+              target="_blank"
+              rel="noreferrer"
+              className="pressable"
+            >
               {link}
-            </a>
+            </Card.Link>
           </Card.Footer>
         </Card.Body>
       </Card>


### PR DESCRIPTION
This PR stet's the `Card.Link` element in the react bootstrap cards but adds "pressable" to its `classNames`. The element's default behavior for clickable things like links was being prevented by the tinder card logic.

See https://github.com/3DJakob/react-tinder-card#buttons-inside-a-tindercard and https://github.com/3DJakob/react-tinder-card/issues/118#issuecomment-1285448533.