### PR TITLE
Handle running out of cards to show

### DIFF
--- a/src/components/Card/CardList.test.tsx
+++ b/src/components/Card/CardList.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import React from "react";
 import * as ReactRouterDOM from "react-router-dom";
 
@@ -66,8 +66,93 @@ describe("CardList component", () => {
     );
   });
 
-  it("adds a card link to localstorage when card item is swiped", () => {
-    // TODO
+  describe("there are no more cards to show", () => {
+    beforeEach(() => {
+      const params = { category: "category-3" };
+      jest.spyOn(ReactRouterDOM, "useParams").mockReturnValue(params);
+    });
+
+    it("displays a message about reaching the end", () => {
+      const { getByRole, getByLabelText, getByText } = render(
+        <CardList {...mockCardListProps} />
+      );
+      const cardItems = getByRole("list");
+      const leftButton = getByLabelText("left-button");
+
+      for (let index = 0; index < cardItems.childNodes.length; index++) {
+        fireEvent.click(leftButton);
+      }
+
+      const reachedTheEndText = getByText(
+        "Looks like you've reached the end. Please check back later. We add new content regularly!"
+      );
+
+      expect(reachedTheEndText).toBeInTheDocument();
+    });
+
+    it("provides a link to reset skipped or missed cards if cards have been skipped", () => {
+      const { getByRole, getByLabelText, queryByLabelText } = render(
+        <CardList {...mockCardListProps} />
+      );
+      const cardItems = getByRole("list");
+      const leftButton0 = getByLabelText("left-button");
+
+      for (let index = 0; index < cardItems.childNodes.length; index++) {
+        fireEvent.click(leftButton0);
+      }
+      const leftButtonAfterSkips = queryByLabelText("left-button");
+
+      expect(leftButtonAfterSkips).toBeNull();
+      const reviewLink = getByLabelText("review-link");
+      expect(reviewLink).toBeInTheDocument();
+
+      fireEvent.click(reviewLink);
+      const leftButtonAfterClickingReviewLink = getByLabelText("left-button");
+      expect(leftButtonAfterClickingReviewLink).toBeInTheDocument();
+    });
+
+    it("provides a link to reset skipped or missed cards if cards have been missed", () => {
+      // TODO
+    });
+
+    it("provides a link to uncompleted cards in all categories if there are any uncompleted cards in other categories", () => {
+      const { getByRole, getByLabelText } = render(
+        <CardList {...mockCardListProps} />
+      );
+      const cardItems = getByRole("list");
+      const leftButton0 = getByLabelText("left-button");
+
+      for (let index = 0; index < cardItems.childNodes.length; index++) {
+        fireEvent.click(leftButton0);
+      }
+
+      const allCategoriesLink = getByLabelText("all-categories-link");
+      expect(allCategoriesLink).toBeInTheDocument();
+
+      fireEvent.click(allCategoriesLink);
+      // TODO: test that after the clicking the link, user is routed to view with cards in all categories with uncompleted cards
+    });
+
+    it("does not provide a link to uncompleted cards in all categories if there are no uncompleted cards in other categories", () => {
+      // Mock that the first card item, which is not category-3, is completed
+      // So there are no uncompleted cards in other categories
+      jest
+        .spyOn(Object.getPrototypeOf(window.localStorage), "getItem")
+        .mockReturnValue(JSON.stringify([cardItemData[0].link]));
+
+      const { getByRole, getByLabelText, queryByLabelText } = render(
+        <CardList {...mockCardListProps} />
+      );
+      const cardItems = getByRole("list");
+      const leftButton0 = getByLabelText("left-button");
+
+      for (let index = 0; index < cardItems.childNodes.length; index++) {
+        fireEvent.click(leftButton0);
+      }
+
+      const allCategoriesLink = queryByLabelText("all-categories-link");
+      expect(allCategoriesLink).toBeNull();
+    });
   });
 
   // it("calls the onSwipe function when a card is swiped", () => {

--- a/src/components/Card/CardList.tsx
+++ b/src/components/Card/CardList.tsx
@@ -158,13 +158,19 @@ export function CardList({
           <Row className="mt-3 justify-content-between">
             <Col md={3} xs={1} />
             <Col className="d-flex align-items-center justify-content-center">
-              <Button onClick={() => swipe("left")}>{"<"} Left to skip!</Button>
+              <Button aria-label="left-button" onClick={() => swipe("left")}>
+                {"<"} Left to skip!
+              </Button>
             </Col>
             {/* <Col>
       <Button onClick={() => goBack()}>Undo swipe!</Button>
     </Col> */}
             <Col className="d-flex align-items-center justify-content-center">
-              <Button onClick={() => swipe("right")} variant="secondary">
+              <Button
+                onClick={() => swipe("right")}
+                variant="secondary"
+                aria-label="right-button"
+              >
                 Right for a quiz! {">"}
               </Button>
             </Col>
@@ -177,13 +183,14 @@ export function CardList({
           <Col>
             <p>
               Looks like you&apos;ve reached the end. Please check back later.
-              We are constantly adding new content!
+              We add new content regularly!
             </p>
             {areSkippedOrMissedCards() && (
               <p>
                 Click{" "}
                 <a
                   href="/"
+                  aria-label="review-link"
                   onClick={(event) => {
                     event.preventDefault();
                     setup();
@@ -196,7 +203,11 @@ export function CardList({
             )}
             {areMoreCards && (
               <p>
-                Click <a href="/">here</a> to learn something new.
+                Click{" "}
+                <a href="/" aria-label="all-categories-link">
+                  here
+                </a>{" "}
+                to learn something new.
               </p>
             )}
           </Col>

--- a/src/components/Card/CardList.tsx
+++ b/src/components/Card/CardList.tsx
@@ -28,7 +28,7 @@ export function CardList({
   const [cards, setCards] = useState<CardItemData[]>([]);
   const [currentIndex, setCurrentIndex] = useState<number>(0);
   const currentIndexRef = useRef(currentIndex);
-  const [skipped, setSkipped] = useState<boolean>(false);
+  const [anySkipped, setAnySkipped] = useState<boolean>(false);
   const [areMoreCards, setAreMoreCards] = useState<boolean>(false);
 
   const getCompletedContentLinks = (): string[] => {
@@ -82,7 +82,7 @@ export function CardList({
     updateCurrentIndex(index - 1);
     if (direction === "left" || direction === "down") {
       removeCard(cards[index]);
-      setSkipped(true);
+      setAnySkipped(true);
     } else {
       selectCard(cards[index]);
     }
@@ -111,11 +111,11 @@ export function CardList({
       );
     setCards(cardsToShow.sort(() => Math.random() - 0.5));
     setCurrentIndex(cardsToShow.length - 1);
-    setSkipped(false);
+    setAnySkipped(false);
   };
 
   const areSkippedOrMissedCards = (): boolean => {
-    if (skipped) return skipped;
+    if (anySkipped) return anySkipped;
 
     const linksToShow = cards.map((card) => card.link);
     const completedCardLinks = getCompletedContentLinks();


### PR DESCRIPTION
This PR:
- shows a message when the user runs out of content cards in the view
- shows a message with a link that essentially resets the view with the skipped and missed cards, **if there are any**
- shows a message with a link that routes to "/" **if there are uncompleted cards/quizzes in _other_ categories**
<img width="1391" alt="Screenshot 2023-04-04 at 16 43 25" src="https://user-images.githubusercontent.com/6839162/229829760-430ae24b-4436-47dc-9269-5f4e2d88e407.png">
